### PR TITLE
Updates AWS SCP for S3 encryption enforcement

### DIFF
--- a/prevention/aws/scp/enforce-encryption-s3-buckets/scp.json
+++ b/prevention/aws/scp/enforce-encryption-s3-buckets/scp.json
@@ -1,29 +1,18 @@
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "*",
-      "Effect": "Deny",
-      "Condition": {
-        "StringNotEquals": {
-          "s3:x-amz-server-side-encryption": "AES256"
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DenyUnEncryptedObjectUploads",
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": "*",
+            "Effect": "Deny",
+            "Condition": {
+                "Null": {
+                    "s3:x-amz-server-side-encryption": true
+                }
+            }
         }
-      }
-    },
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "*",
-      "Effect": "Deny",
-      "Condition": {
-        "Bool": {
-          "s3:x-amz-server-side-encryption": false
-        }
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
This policy is meant to generically require encryption, regardless of the method of said encryption. Therefore, this policy now only checks that s3:x-amz-server-side-encryption is provided by the client. Note that the validation of the content of that header is handled by AWS, and therefore can not be circumvented.