### PR TITLE
Adds AWS SCP Prevention Bots

### DIFF
--- a/prevention/aws/scp/deny-removal-of-IMDSv2/manifest.yaml
+++ b/prevention/aws/scp/deny-removal-of-IMDSv2/manifest.yaml
@@ -2,7 +2,7 @@
 version: 2020-04-16
 type: Prevention
 title: Deny Removal of IMDSv2
-description: This SCP denies the ability for a user to remove the enforcement of IMDSv2 on EC2 instances.
+description: This SCP denies the ability for someone to remove the enforcement of IMDSv2 on EC2 instances.
 cloud: AWS
 operation: ATTACH_AWS_SCP
 authorName: Sonrai Security

--- a/prevention/aws/scp/deny-removal-of-IMDSv2/manifest.yaml
+++ b/prevention/aws/scp/deny-removal-of-IMDSv2/manifest.yaml
@@ -1,0 +1,9 @@
+# Built-in Sonrai Bot: srn:supersonrai::bot/bd72af28-7ffa-11ea-bc55-0242ac130003
+version: 2020-04-16
+type: Prevention
+title: Deny Removal of IMDSv2
+description: This SCP denies the ability for a user to remove the enforcement of IMDSv2 on EC2 instances.
+cloud: AWS
+operation: ATTACH_AWS_SCP
+authorName: Sonrai Security
+authorEmail: info@sonraisecurity.com

--- a/prevention/aws/scp/deny-removal-of-IMDSv2/scp.json
+++ b/prevention/aws/scp/deny-removal-of-IMDSv2/scp.json
@@ -1,0 +1,9 @@
+{
+  "Version": "2012-10-17",
+  "Statement":
+  {
+    "Effect": "Deny",
+    "Action": "ec2:ModifyInstanceMetadataOptions",
+    "Resource": "*"
+  }
+}

--- a/prevention/aws/scp/enforce-ec2-IMDSv2/manifest.yaml
+++ b/prevention/aws/scp/enforce-ec2-IMDSv2/manifest.yaml
@@ -1,0 +1,9 @@
+# Built-in Sonrai Bot: srn:supersonrai::bot/b1e703ea-7ff8-11ea-bc55-0242ac130003
+version: 2020-04-16
+type: Prevention
+title: Enforce IMDSv2 for EC2 Instances
+description: This SCP ensures that EC2 instances can only be created if you enforce that they use IMDSv2. This will not impact existing EC2 instances.
+cloud: AWS
+operation: ATTACH_AWS_SCP
+authorName: Sonrai Security
+authorEmail: info@sonraisecurity.com

--- a/prevention/aws/scp/enforce-ec2-IMDSv2/scp.json
+++ b/prevention/aws/scp/enforce-ec2-IMDSv2/scp.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement":
+  {
+    "Sid": "RequireImdsV2",
+    "Effect": "Deny",
+    "Action": "ec2:RunInstances",
+    "Resource": "arn:aws:ec2:::instance/*",
+    "Condition":
+    {
+      "StringNotEquals":
+      {
+        "ec2:MetadataHttpTokens": "required",
+      }
+    }
+  }
+}

--- a/prevention/aws/scp/enforce-ec2-IMDSv2/scp.json
+++ b/prevention/aws/scp/enforce-ec2-IMDSv2/scp.json
@@ -10,7 +10,7 @@
     {
       "StringNotEquals":
       {
-        "ec2:MetadataHttpTokens": "required",
+        "ec2:MetadataHttpTokens": "required"
       }
     }
   }

--- a/prevention/aws/scp/require-ec2-roles-use-IMDSv2/manifest.yaml
+++ b/prevention/aws/scp/require-ec2-roles-use-IMDSv2/manifest.yaml
@@ -1,0 +1,9 @@
+# Built-in Sonrai Bot: srn:supersonrai::bot/45870b44-7ffa-11ea-bc55-0242ac130003
+version: 2020-04-16
+type: Prevention
+title: Require EC2 Roles Use IMDSv2
+description: This SCP will require role credentials for an EC2 instance to have been retrieved using the IMDSv2. This policy can be applied generally to entire account as it only impacts the principals when they have the ec2:RoleDelivery variable associated with them, which will only happen on EC2 instances.
+cloud: AWS
+operation: ATTACH_AWS_SCP
+authorName: Sonrai Security
+authorEmail: info@sonraisecurity.com

--- a/prevention/aws/scp/require-ec2-roles-use-IMDSv2/scp.json
+++ b/prevention/aws/scp/require-ec2-roles-use-IMDSv2/scp.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RequireAllEc2RolesToUseV2",
+      "Effect": "Deny",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
+        "NumericLessThan": {
+          "ec2:RoleDelivery": "2.0"
+        }
+      }
+    }
+  ]
+}

--- a/prevention/aws/scp/restrict-ec2-hop-count/manifest.yaml
+++ b/prevention/aws/scp/restrict-ec2-hop-count/manifest.yaml
@@ -1,0 +1,9 @@
+# Built-in Sonrai Bot: srn:supersonrai::bot/1ca0d158-7ffd-11ea-bc55-0242ac130003
+version: 2020-04-16
+type: Prevention
+title: Restrict EC2 Hop Count to 1
+description: This SCP strengthens the use of IMDSv2 by restricting the EC2 hop count to 1.
+cloud: AWS
+operation: ATTACH_AWS_SCP
+authorName: Sonrai Security
+authorEmail: info@sonraisecurity.com

--- a/prevention/aws/scp/restrict-ec2-hop-count/scp.json
+++ b/prevention/aws/scp/restrict-ec2-hop-count/scp.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement":
+  {
+    "Sid": "MaxImdsHopLimit",
+    "Effect": "Deny",
+    "Action": "ec2:RunInstances",
+    "Resource": "arn:aws:ec2:::instance/*",
+    "Condition":
+    {
+      "NumericGreaterThan":
+      {
+        "ec2:MetadataHttpPutResponseHopLimit": "1"
+      }
+    }
+  }
+}

--- a/sonrai-bots.iml
+++ b/sonrai-bots.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/sonrai-bots.iml
+++ b/sonrai-bots.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
The following AWS SCP Prevention Bots are added:
- Deny Removal of IMDSv2
- Enforce IMDSv2 for EC2 Instances
- Require EC2 Roles Use IMDSv2
- Restrict EC2 Hop Count to 1