### PR TITLE
Fixing search to avoid missing AWS accounts

### DIFF
--- a/remediation/aws/add_account_to_monitor/bot.py
+++ b/remediation/aws/add_account_to_monitor/bot.py
@@ -43,7 +43,6 @@ def run(ctx):
       Accounts(
         where: {
           cloudType: { op: EQ, value: "aws" }
-          type: { op: IN_LIST, values: [AWSAccount] }
           tagSet: {
             op: NOT_CONTAINS
             value: "sonraiBotAdded"

--- a/remediation/aws/add_account_to_monitor/manifest.yaml
+++ b/remediation/aws/add_account_to_monitor/manifest.yaml
@@ -4,5 +4,5 @@ type: Remediation
 title: Add AWS Account to Sonrai
 operation: EXECUTE_PYTHON_SCRIPT
 authorName: Sonrai Security
-cloud: ANY
+cloud: AWS
 authorEmail: info@sonraisecurity.com


### PR DESCRIPTION
…and also moving from ANY cloud to AWS since they need an AWS collector to add AWS accounts anyway.  This will make it less confusing for troubleshooting