### PR TITLE
fix: SAR-13494 fix the scenario where invalid resource IDs are present

### DIFF
--- a/remediation/azure/add_subscription_to_monitor/bot.py
+++ b/remediation/azure/add_subscription_to_monitor/bot.py
@@ -99,15 +99,18 @@ def run(ctx):
        AddTag(value: {key: $key, value: $value, tagsEntity: {add: [$srn]}}) {srn key value }} 
     '''
 
-
-
     for resourceId in r_subscriptions['Subscriptions']['items']:
-        #step through all subscriptions to see if it is already added to a collector
+        # step through all subscriptions to see if it is already added to a collector
         add_subscription = True
-        subscriptionToAdd = re.sub("\/subscriptions\/","", resourceId['resourceId'])
         subscription_srn = resourceId['srn']
+        try:
+            subscriptionToAdd = re.sub("\/subscriptions\/", "", resourceId['resourceId'])
+        except TypeError as e:
+            logging.error("Encountered an invalid or null resourceId for subscription resourceID:'{}' srn:'{}'".format(resourceId, subscription_srn))
+            logging.error(e)
+            continue
 
-        #check if the subscriptionToAdd is already added
+        # check if the subscriptionToAdd is already added
         for existing_subscriptions in r_platform_subscriptions['PlatformCloudAccounts']['items']:
             subscriptionId = existing_subscriptions['blob']['subscriptionId']
             if subscriptionToAdd == subscriptionId:

--- a/remediation/azure/add_subscription_to_monitor/manifest.yaml
+++ b/remediation/azure/add_subscription_to_monitor/manifest.yaml
@@ -1,5 +1,5 @@
 # Built-in Sonrai Bot: srn:supersonrai::bot/e75a4016-ab2f-40cb-a906-901eb445e869
-version: 2020-12-21
+version: 2022-06-29
 type: Remediation
 title: Add Azure Subscription to Sonrai
 operation: EXECUTE_PYTHON_SCRIPT


### PR DESCRIPTION
Currently the bot fails if it is presented with an invalid resource ID.
This fix will make certain it catches those ones logs it and moves
forward.

https://sonraisecurity.atlassian.net/browse/SAR-12394