### PR TITLE
fix(SAR-12761): fix large query results

### DIFF
--- a/remediation/aws/add_account_to_monitor/bot.py
+++ b/remediation/aws/add_account_to_monitor/bot.py
@@ -65,7 +65,7 @@ def run(ctx):
         }
     ) {
       count
-      items {
+      items (limit: -1) {
         account
         srn
         tagSet
@@ -88,7 +88,7 @@ def run(ctx):
   )
   {
     count
-    items {
+    items (limit: -1) {
       cloudType
       blob
     }
@@ -198,7 +198,7 @@ def run(ctx):
         query SwimlaneSRN($title: String) {
           Swimlanes(where: { title: { op: EQ, value: $title } }) {
             count
-            items {
+            items (limit: -1) {
               srn
             }
           }

--- a/remediation/azure/add_subscription_to_monitor/bot.py
+++ b/remediation/azure/add_subscription_to_monitor/bot.py
@@ -44,7 +44,7 @@ def run(ctx):
         }
         ){
     count
-    items {
+    items (limit: -1) {
       type
       cloudType
       account
@@ -69,7 +69,7 @@ def run(ctx):
   )
   {
     count
-    items {
+    items (limit: -1) {
       cloudType
       blob
     }

--- a/remediation/gcp/add_project_to_monitor/graphql/gcpCloudAccounts.gql
+++ b/remediation/gcp/add_project_to_monitor/graphql/gcpCloudAccounts.gql
@@ -7,7 +7,7 @@ query CloudAccounts {
   )
   {
     count
-    items {
+    items (limit: -1) {
       blob
    }
  }

--- a/remediation/gcp/add_project_to_monitor/graphql/gcpProjects.gql
+++ b/remediation/gcp/add_project_to_monitor/graphql/gcpProjects.gql
@@ -8,7 +8,7 @@ query gcpprojects {
     }
   ) {
     count
-    items {
+    items (limit: -1) {
       project_id: account @regex(match: "GCPProject.(.*)", replace: "$1")
       srn
     }


### PR DESCRIPTION
Current version of bots don't take into consideration tenants with large number cloud accounts. This fix handles it by adding (limit: -1) to queries